### PR TITLE
Remove stray colon in client constructor example

### DIFF
--- a/lib/fitgem/client.rb
+++ b/lib/fitgem/client.rb
@@ -39,7 +39,7 @@ module Fitgem
     #     :consumer_key => my_key,
     #     :consumer_secret => my_secret,
     #     :token => fitbit_oauth_token,
-    #     :secret => :fitbit_oauth_secret,
+    #     :secret => fitbit_oauth_secret,
     #     :unit_system => Fitgem::ApiUnitSystem.METRIC
     #   }
     attr_accessor :api_unit_system


### PR DESCRIPTION
There was an unneeded colon in the client constructor example, making the `fitbit_oauth_secret` variable a symbol. (`:fitbit_oauth_secret`)
