### PR TITLE
Get Intraday activity for :distance

### DIFF
--- a/lib/fitgem/activities.rb
+++ b/lib/fitgem/activities.rb
@@ -158,8 +158,8 @@ module Fitgem
     #
     # @return [Hash] A hash containing time series data
     def intraday_time_series(opts)
-      unless opts[:resource] && [:calories, :steps, :floors, :elevation].include?(opts[:resource])
-        raise Fitgem::InvalidArgumentError, 'Must specify resource to fetch intraday time series data for. One of (:calories, :steps, :floors, or :elevation) is required.'
+      unless opts[:resource] && [:calories, :steps, :distance, :floors, :elevation].include?(opts[:resource])
+        raise Fitgem::InvalidArgumentError, 'Must specify resource to fetch intraday time series data for. One of (:calories, :steps, :distance, :floors, or :elevation) is required.'
       end
 
       unless opts[:date]

--- a/spec/fitgem_activities_spec.rb
+++ b/spec/fitgem_activities_spec.rb
@@ -36,6 +36,15 @@ describe Fitgem::Client do
       }.to raise_error(Fitgem::InvalidArgumentError)
     end
 
+    it 'valid resources should not raise an error' do
+      [:calories, :steps, :distance, :floors, :elevation].each do |resource|
+        opts = { resource: resource, date: '2013-05-13', detailLevel: '15min' }
+        expect{
+          @client.intraday_time_series(opts)          
+        }.not_to raise_error
+      end
+    end
+
     it 'raises an exception if the date is missing' do
       expect {
         @client.intraday_time_series(@date_opts.merge!(date: nil))


### PR DESCRIPTION
The fitbit intraday_time_series api returns :distance in addition to the other resources that were already part of this gem.

This pull request adds distance.

https://wiki.fitbit.com/display/API/API-Get-Intraday-Time-Series
