### PR TITLE
Update for Weekly Leaderboard API endpoint

### DIFF
--- a/lib/fitgem/errors.rb
+++ b/lib/fitgem/errors.rb
@@ -22,4 +22,7 @@ module Fitgem
 
   class ConnectionRequiredError < Exception
   end
+
+  class DeprecatedApiError < Exception
+  end
 end

--- a/lib/fitgem/friends.rb
+++ b/lib/fitgem/friends.rb
@@ -23,7 +23,7 @@ module Fitgem
     #
     # @return [Hash] Friends' information
     def monthly_leaderboard
-      leaderboard('30d')
+      raise DeprecatedApiError, 'Fitbit no longer exposes a monthly leaderboard. See https://wiki.fitbit.com/display/API/API-Get-Friends-Leaderboard for more information.'
     end
 
     # ==========================================


### PR DESCRIPTION
The current weekly and monthly leaderboard methods make requests that no longer appear supported. When using those methods the summary, lifetime, average, etc. values in the response are all zero.

Browsing the API documentation, I found [this](https://wiki.fitbit.com/display/API/API-Get-Friends-Leaderboard) endpoint that returns the last 7 days data. This pull request updates the `weekly_leaderboard` to call that endpoint instead.
