### PR TITLE
Replaced the leaders endpoint with the actual leaderboard endpoint.

### DIFF
--- a/lib/fitgem/friends.rb
+++ b/lib/fitgem/friends.rb
@@ -12,10 +12,10 @@ module Fitgem
       get("/user/#{@user_id}/friends.json")
     end
 
-    # Get the weekly leaderboard of friends' activities
+    # Get the leaderboard of friends' weekly activities
     #
     # @return [Hash] Friends' information
-    def weekly_leaderboard
+    def leaderboard
       get("/user/#{@user_id}/friends/leaderboard.json")
     end
 


### PR DESCRIPTION
The leaders endpoint returns friends only without ranking or other leaderboard data, so it isn't really useful since it doesn't return the expected data.

Therefor I implemented the new leaderboard endpoint (there only is a weekly leaderboard though, see: https://wiki.fitbit.com/display/API/API-Get-Friends-Leaderboard).
