### PR TITLE
Force SSL API calls per #30

### DIFF
--- a/lib/fitgem/client.rb
+++ b/lib/fitgem/client.rb
@@ -30,11 +30,6 @@ module Fitgem
     # @return [String]
     attr_accessor :api_version
 
-    # Sets or gets the ssl settings
-    # 
-    # @return [Boolean]
-    attr_accessor :ssl
-    
     # Sets or gets the api unit system to be used in API calls
     #
     # @return [String]
@@ -102,8 +97,6 @@ module Fitgem
       end
       @consumer_key = opts[:consumer_key]
       @consumer_secret = opts[:consumer_secret]
-
-      @ssl = opts[:ssl]
 
       @token = opts[:token]
       @secret = opts[:secret]
@@ -182,19 +175,12 @@ module Fitgem
       consumer.options[:authorize_path] = '/oauth/authenticate'
       request_token(opts)
     end
-    
-    # The protocol to be used for the API requests
-    # 
-    # @return [String], 'http', or 'https' if ssl == true
-    def protocol
-      ssl ? "https" : "http"
-    end
 
     private
 
       def consumer
         @consumer ||= OAuth::Consumer.new(@consumer_key, @consumer_secret, {
-          :site => "#{protocol}://api.fitbit.com",
+          :site => 'https://api.fitbit.com',
           :proxy => @proxy
         })
       end

--- a/spec/fitgem_spec.rb
+++ b/spec/fitgem_spec.rb
@@ -32,33 +32,5 @@ describe Fitgem do
     it 'should default to a user id of \'-\', the currently-logged in user' do
       @client.user_id.should == '-'
     end
-    
-    it "returns the protocol to be used" do
-      @client.protocol.should eq "http"
-    end
-    
-    describe "ssl" do
-      it "should expose the ssl setting" do
-        @client.ssl.should eq nil
-      end
-      
-      context "when true" do
-        let(:client) { Fitgem::Client.new({
-            :consumer_key => '12345', 
-            :consumer_secret => '67890',
-            :ssl => true
-          }) }
-          
-        it "can set the ssl setting to true" do
-          client.ssl.should be_true
-        end
-        
-        it "uses https protocol" do
-          client.protocol.should eq "https"
-        end
-        
-      end
-      
-    end
   end
 end


### PR DESCRIPTION
I generally don't like submitting PRs where I'm removing tests, instead of adding them. This case, however, the bulk of what I did was remove a method and the calls to it. The only remaining method that was changed is a private method, so I thought it best not to test that.

This should force calls to the fitbit API over SSL per their latest email saying they are going to start forcing SSL soon.

The only error I'm getting from rspec seems to be related to an rspec 3 syntax issue. I noticed someone else submitted a PR fixing that. :beers: 
