### PR TITLE
Allow reuse of client with different credentials

### DIFF
--- a/lib/fitgem/client.rb
+++ b/lib/fitgem/client.rb
@@ -146,6 +146,7 @@ module Fitgem
     #   needed to make API calls, since it is stored internally.  It is
     #   returned so that you may make general OAuth calls if need be.
     def reconnect(token, secret)
+      @access_token = nil
       @token = token
       @secret = secret
       access_token

--- a/spec/fitgem_spec.rb
+++ b/spec/fitgem_spec.rb
@@ -33,4 +33,16 @@ describe Fitgem do
       expect(@client.user_id).to eq '-'
     end
   end
+
+  describe '#reconnect' do
+    it 'resets the access token' do
+      access_token = @client.reconnect('abc', '123')
+      expect(access_token.token).to eq('abc')
+      expect(access_token.secret).to eq('123')
+
+      access_token = @client.reconnect('def', '456')
+      expect(access_token.token).to eq('def')
+      expect(access_token.secret).to eq('456')
+    end
+  end
 end


### PR DESCRIPTION
This pull request addresses the use case where you want to setup a single client with your fitbit consumer key and secret, but then use it across multiple users' oauth credentials, rather than creating a new client per user.  The reconnect method provides 99% of this functionality already, but because the access token is `||=` 'ed, it doesn't actually get reset, and further API calls all use the first set of credentials.