### PR TITLE
Raise custom exception when service is unavailable (503 status).

### DIFF
--- a/lib/fitgem/client.rb
+++ b/lib/fitgem/client.rb
@@ -220,8 +220,12 @@ module Fitgem
         access_token.delete(uri, headers)
       end
 
-      def extract_response_body(resp)
-        resp.nil? || resp.body.nil? ? {} : JSON.parse(resp.body)
+      def extract_response_body(response)
+        return {} if response.nil?
+
+        raise ServiceUnavailableError if response.code == '503'
+
+        response.body.nil? ? {} : JSON.parse(response.body)
       end
   end
 end

--- a/lib/fitgem/errors.rb
+++ b/lib/fitgem/errors.rb
@@ -25,4 +25,7 @@ module Fitgem
 
   class DeprecatedApiError < Exception
   end
+
+  class ServiceUnavailableError < Exception
+  end
 end

--- a/spec/fitgem_client_spec.rb
+++ b/spec/fitgem_client_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+RSpec.describe Fitgem::Client do
+  let(:access_token) { double 'Access Token', :get => response }
+  let(:client)       { Fitgem::Client.new({
+    :consumer_key => '12345',
+    :consumer_secret => '67890'
+  }) }
+  let(:response)     { double :body => {:foo => :bar}.to_json, :code => 200 }
+
+  before :each do
+    allow(OAuth::AccessToken).to receive(:new).and_return(access_token)
+  end
+
+  it 'returns JSON from the request' do
+    expect(client.user_info).to eq({'foo' => 'bar'})
+  end
+
+  it 'raises a service unavailable exception when the status is 503' do
+    allow(response).to receive(:code).and_return('503')
+
+    expect { client.user_info }.to raise_error(Fitgem::ServiceUnavailableError)
+  end
+end

--- a/spec/fitgem_notifications_spec.rb
+++ b/spec/fitgem_notifications_spec.rb
@@ -56,7 +56,7 @@ describe Fitgem::Client do
 
     it "returns the code and the JSON body in an array" do
       opts = { :subscriber_id => "5555", :type => :all, :subscription_id => "320", :use_subscription_id => true }
-      expect(@resp).to receive(:code)
+      expect(@resp).to receive(:code).twice
       expect(@client.create_subscription(opts)).to be_a(Array)
     end
   end
@@ -87,7 +87,7 @@ describe Fitgem::Client do
 
     it "returns the code and the JSON body in an array" do
       opts = { :subscriber_id => "5555", :type => :all, :subscription_id => "320", :use_subscription_id => true }
-      expect(@resp).to receive(:code)
+      expect(@resp).to receive(:code).twice
       expect(@client.remove_subscription(opts)).to be_a(Array)
     end
   end


### PR DESCRIPTION
Fitbit's servers seem to be extra flakey lately, and I'd like to handle an exception when they respond with a 503 (instead of a JSON::ParserError due to HTML being returned for the 503 error).