### PR TITLE
Make response headers available to caller

### DIFF
--- a/lib/fitgem/client.rb
+++ b/lib/fitgem/client.rb
@@ -214,7 +214,7 @@ module Fitgem
       end
 
       def get(path, headers={})
-        extract_response_body raw_get(path, headers)
+        extract_response_body_and_headers raw_get(path, headers)
       end
 
       def raw_get(path, headers={})
@@ -225,7 +225,7 @@ module Fitgem
       end
 
       def post(path, body='', headers={})
-        extract_response_body raw_post(path, body, headers)
+        extract_response_body_and_headers raw_post(path, body, headers)
       end
 
       def raw_post(path, body='', headers={})
@@ -236,7 +236,7 @@ module Fitgem
       end
 
       def delete(path, headers={})
-        extract_response_body raw_delete(path, headers)
+        extract_response_body_and_headers raw_delete(path, headers)
       end
 
       def raw_delete(path, headers={})
@@ -246,6 +246,12 @@ module Fitgem
         access_token.delete(uri, headers)
       end
 
+      def extract_response_body_and_headers(response)
+        body = extract_response_body(response)
+        headers = extract_response_headers(response)
+        body.merge('http_headers' => headers)
+      end
+
       def extract_response_body(response)
         return {} if response.nil?
 
@@ -253,5 +259,15 @@ module Fitgem
 
         response.body.nil? ? {} : JSON.parse(response.body)
       end
+
+     def extract_response_headers(resp)
+       result = {}
+
+       if !resp.nil?
+         resp.each_header { |key, value| result[key] = value }
+       end
+
+       result
+     end
   end
 end

--- a/lib/fitgem/notifications.rb
+++ b/lib/fitgem/notifications.rb
@@ -28,7 +28,7 @@ module Fitgem
     # @since v0.4.0
     def create_subscription(opts)
       resp = raw_post make_subscription_url(opts.merge({:use_subscription_id => true})), EMPTY_BODY, make_headers(opts)
-      [resp.code, extract_response_body(resp)]
+      [resp.code, extract_response_body_and_headers(resp)]
     end
 
     # Removes a notification subscription
@@ -49,7 +49,7 @@ module Fitgem
     # @since v0.4.0
     def remove_subscription(opts)
       resp = raw_delete make_subscription_url(opts.merge({:use_subscription_id => true})), make_headers(opts)
-      [resp.code, extract_response_body(resp)]
+      [resp.code, extract_response_body_and_headers(resp)]
     end
 
     protected

--- a/spec/fitgem_notifications_spec.rb
+++ b/spec/fitgem_notifications_spec.rb
@@ -50,7 +50,7 @@ describe Fitgem::Client do
 
     it "calls #extract_response_body to get the JSON body" do
       opts = { :subscriber_id => "5555", :type => :all, :subscription_id => "320", :use_subscription_id => true }
-      expect(@client).to receive(:extract_response_body)
+      expect(@client).to receive(:extract_response_body_and_headers)
       @client.create_subscription(opts)
     end
 
@@ -81,7 +81,7 @@ describe Fitgem::Client do
 
     it "calls #extract_response_body to get the JSON body" do
       opts = { :subscriber_id => "5555", :type => :all, :subscription_id => "320", :use_subscription_id => true }
-      expect(@client).to receive(:extract_response_body)
+      expect(@client).to receive(:extract_response_body_and_headers)
       @client.remove_subscription(opts)
     end
 


### PR DESCRIPTION
This is especially useful for the rate limit headers returned by fitbit's api
https://wiki.fitbit.com/display/API/Rate+Limit

Getting Fitbit's rate limit information to the client application allows the application to better schedule calls to Fitbit's api.