### PR TITLE
Log body fat: URL path was incorrect.

### DIFF
--- a/lib/fitgem/body_measurements.rb
+++ b/lib/fitgem/body_measurements.rb
@@ -138,7 +138,7 @@ module Fitgem
       opts[:fat] = fatPercentage
       opts[:date] = format_date(date)
       opts[:time] = format_time(opts[:time]) if opts[:time]
-      post("/user/#{@user_id}/body/fat.json", opts)
+      post("/user/#{@user_id}/body/log/fat.json", opts)
     end
 
     # Create or update a user's weight goal

--- a/lib/fitgem/version.rb
+++ b/lib/fitgem/version.rb
@@ -1,3 +1,3 @@
 module Fitgem
-  VERSION = '0.12.1'
+  VERSION = '0.13.0'
 end


### PR DESCRIPTION
The URL for Log Body Fat was missing a path component.

Bumped the gem version as part of this change.